### PR TITLE
CI Test suite (Fixes #3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,19 @@
-language: bash
+language: julia
+
+os:
+  - linux
+  - osx
+
+julia:
+  - release
+  - nightly
+  - 0.5
+
+matrix:
+  allow_failures:
+    - julia: nightly
 
 script:
-  - bin/fetch-configlet
-  - bin/configlet .
+  - julia runtests.jl
+  - ./bin/fetch-configlet
+  - ./bin/configlet .

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please see the [contributing guide](https://github.com/exercism/x-common/blob/ma
 
 A pool of exercises can be found in the [x-Common repo](https://github.com/exercism/x-common).
 
-Exercises for the Julia track go in the `exercises` directory and should follow the following filename conventions: 
+Exercises for the Julia track go in the `exercises` directory and should follow the following filename conventions:
 
 `exercises/<slug>/<slug>.jl` Skeleton for the function that is called by the test suite. Provide (abstract) parameter and return types to ensure compatibility with the test suite.
 
@@ -25,3 +25,6 @@ Exercises for the Julia track go in the `exercises` directory and should follow 
 Replace `<slug>` with the exercise slug of the exercise you're working on.
 
 See [Issue #2](https://github.com/exercism/xjulia/issues/2) for discussion on the structure.
+
+### Testing the example solutions
+Test your example solutions by running `julia runtests.jl` in the project directory. Specify exercise slugs as arguments to run only certain exercises: `julia runtests.jl <slug>`.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,0 +1,5 @@
+# Running the tests
+Place yourself in the directory where the exercise has been fetched and run:
+```bash
+julia runtests.jl
+```

--- a/runtests.jl
+++ b/runtests.jl
@@ -1,0 +1,32 @@
+using Base.Test
+
+for (root, dirs, files) in walkdir("exercises")
+    for exercise in dirs
+        # Allow only testing specified execises
+        if !isempty(ARGS) && !(exercise in ARGS)
+            continue
+        end
+
+        exercise_path = joinpath("exercises", exercise)
+
+        # Create temporary directory
+        temp_path = mktempdir(root)
+
+        # Copy tests & example to the temporary directory
+        cp(joinpath(exercise_path, "example.jl"), joinpath(temp_path, "$exercise.jl"))
+        cp(joinpath(exercise_path, "runtests.jl"), joinpath(temp_path, "runtests.jl"))
+
+        # Run the tests
+        result = @testset "$exercise example" begin
+            include(joinpath(temp_path, "runtests.jl"))
+        end
+
+        # Delete the temporary directory
+        rm(temp_path, recursive=true)
+
+        # Print test output (this is the default behaviour for older versions of Julia)
+        if VERSION > v"0.6.0-dev"
+            Base.Test.print_test_results(result)
+        end
+    end
+end


### PR DESCRIPTION
This implements a test suite that can be used to run tests locally and on Travis CI. You can specify the example solutions to be tested via command line arguments. The default behaviour is to test all example solutions.

I've tested it both locally and on Travis CI for Julia v0.5 and the latest v0.6-dev build. It seemed to work but please check if I made any mistakes in `.travis.yml` as I don't have much experience with Travis.

(ref. #3)