### PR TITLE
RFC: Fix removal of temp dir if tests fail

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,8 @@
   "ignored": [
     "bin",
     "img",
-    "docs"
+    "docs",
+    "juliamnt"
   ],
   "foregone": [
 

--- a/runtests.jl
+++ b/runtests.jl
@@ -16,13 +16,15 @@ for (root, dirs, files) in walkdir("exercises")
         cp(joinpath(exercise_path, "example.jl"), joinpath(temp_path, "$exercise.jl"))
         cp(joinpath(exercise_path, "runtests.jl"), joinpath(temp_path, "runtests.jl"))
 
-        # Run the tests
-        result = @testset "$exercise example" begin
-            include(joinpath(temp_path, "runtests.jl"))
+        try
+            # Run the tests
+            result = @testset "$exercise example" begin
+                include(joinpath(temp_path, "runtests.jl"))
+            end
+        finally
+            # Delete the temporary directory
+            rm(temp_path, recursive=true)
         end
-
-        # Delete the temporary directory
-        rm(temp_path, recursive=true)
 
         # Print test output (this is the default behaviour for older versions of Julia)
         if VERSION > v"0.6.0-dev"


### PR DESCRIPTION
Currently if one of the tests fails, the temporary directory is not deleted. This should fix this issue.