### PR TITLE
Additional info for adding exercises in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Please see the [contributing guide](https://github.com/exercism/x-common/blob/ma
 
 ## Working on the Exercises
 
+### Implementing an exercise
+
 A pool of exercises can be found in the [x-Common repo](https://github.com/exercism/x-common).
 
 Exercises for the Julia track go in the `exercises` directory and should follow the following filename conventions:
@@ -25,6 +27,20 @@ Exercises for the Julia track go in the `exercises` directory and should follow 
 Replace `<slug>` with the exercise slug of the exercise you're working on.
 
 See [Issue #2](https://github.com/exercism/xjulia/issues/2) for discussion on the structure.
+
+### Adding it to config
+
+Make sure to add the exercise to the `config.json` file, by adding an entry to the `exercises` array:
+```json
+"exercises": [
+  {
+    "slug": "hello-world" ,
+    "difficulty": 1,
+    "topics": ["strings"]
+  }
+]
+```
+If possible, add info on which topics the exercise is about and estimate a difficulty level from 1 to 10. We can adjust these later on when we know more about the exercise and how users solve them.
 
 ### Testing the example solutions
 Test your example solutions by running `julia runtests.jl` in the project directory. Specify exercise slugs as arguments to run only certain exercises: `julia runtests.jl <slug>`.


### PR DESCRIPTION
Add an example exercise entry for config.json in the README to make it easier for new contributors to find info in one place.