### PR TITLE
Remove test_pattern config-key

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,6 @@
   "language": "Julia",
   "repository": "https://github.com/exercism/xjulia",
   "active": false,
-  "test_pattern": "TODO",
   "exercises": [
     {
       "slug": "hello-world",


### PR DESCRIPTION
Our test files are called `runtests.jl` and thus have `test` in the name, so this can be removed. (See #1)