### PR TITLE
Disable osx travis builds & duplicate 0.5 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ language: julia
 
 os:
   - linux
-  - osx
 
 julia:
   - release
   - nightly
-  - 0.5
 
 matrix:
   allow_failures:


### PR DESCRIPTION
* osx builds take ~1h to start, causing issues for other tracks.

* disable the 0.5 build because release covers that as of the time of the PR