### PR TITLE
Add v0.5.0 to travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 julia:
   - release
   - nightly
+  - 0.5.0
 
 matrix:
   allow_failures:


### PR DESCRIPTION
v0.5.1 has been released. While it should be compatible with v0.5, we should still test v0.5 to be sure as it will likely take some time for people to update.