### PR TITLE
Difference of squares: Change order to fit readme

### DIFF
--- a/exercises/difference-of-squares/difference-of-squares.jl
+++ b/exercises/difference-of-squares/difference-of-squares.jl
@@ -1,10 +1,10 @@
-"Square the sum of the numbers up to the given number"
-function sum_of_squares(n::Int)
+"Sum the squares of the numbers up to the given number"
+function square_of_sum(n::Int)
 
 end
 
-"Sum the squares of the numbers up to the given number"
-function square_of_sum(n::Int)
+"Square the sum of the numbers up to the given number"
+function sum_of_squares(n::Int)
 
 end
 


### PR DESCRIPTION
Someone mentioned in a comment that the stub is in a different order than the description. This fixes it.

Trivial change so I'll merge it as soon as tests pass.