### PR TITLE
Optional/Skipped tests will be unskipped on Travis and Development

### DIFF
--- a/exercises/rotational-cipher/runtests.jl
+++ b/exercises/rotational-cipher/runtests.jl
@@ -32,20 +32,20 @@ include("rotational-cipher.jl")
     end
 end
 
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Additional exercises                                                #
-# Remove the comments for the optional bonus exercises from HINTS.md  #
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Additional exercises                                                        #
+# Change @test_skip to @test for the optional bonus exercises from HINTS.md   #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 # Bonus A
-# @testset "string literal R13" begin
-#     @test R13"The quick brown fox jumps over the lazy dog." == "Gur dhvpx oebja sbk whzcf bire gur ynml qbt."
-# end
+@testset "Bonus A: string literal R13" begin
+    @test_skip R13"The quick brown fox jumps over the lazy dog." == "Gur dhvpx oebja sbk whzcf bire gur ynml qbt."
+end
 
 # Bonus B
-# @testset "string literals" begin
-#     @test R5"OMG" == "TRL"
-#     @test R4"Testing 1 2 3 testing" == "Xiwxmrk 1 2 3 xiwxmrk"
-#     @test R21"Let's eat, Grandma!" == "Gzo'n zvo, Bmviyhv!"
-#     @test R13"The quick brown fox jumps over the lazy dog." == "Gur dhvpx oebja sbk whzcf bire gur ynml qbt."
-# end
+@testset "Bonus B: string literals" begin
+    @test_skip R5"OMG" == "TRL"
+    @test_skip R4"Testing 1 2 3 testing" == "Xiwxmrk 1 2 3 xiwxmrk"
+    @test_skip R21"Let's eat, Grandma!" == "Gzo'n zvo, Bmviyhv!"
+    @test_skip R13"The quick brown fox jumps over the lazy dog." == "Gur dhvpx oebja sbk whzcf bire gur ynml qbt."
+end

--- a/runtests.jl
+++ b/runtests.jl
@@ -6,11 +6,11 @@ import Base.Test.@test_skip, Base.Test.@test_broken
 # The track user will not be affected by this.
 # Overwrite @test_skip, @test_broken with @test
 macro test_skip(ex)
-    @test ex
+    @test eval(ex)
 end
 
 macro test_broken(ex)
-    @test ex
+    @test eval(ex)
 end
 
 for (root, dirs, files) in walkdir("exercises")

--- a/runtests.jl
+++ b/runtests.jl
@@ -1,5 +1,18 @@
 using Base.Test
 
+import Base.Test.@test_skip, Base.Test.@test_broken
+
+# When testing the example solution, all tests must pass, even ones marked as skipped or broken.
+# The track user will not be affected by this.
+# Overwrite @test_skip, @test_broken with @test
+macro test_skip(ex)
+    @test ex
+end
+
+macro test_broken(ex)
+    @test ex
+end
+
 for (root, dirs, files) in walkdir("exercises")
     for exercise in dirs
         # Allow only testing specified execises


### PR DESCRIPTION
This finally fixes #45.

Now `@test_skip` and `@test_broken` will be overwritten with `@test` when running the tests via `runtests.jl` in the main directory. *This does not affect the person solving the exercise.*

~This only works on v0.6, so won't merge it before v0.6 launches (just like #58).~ Seems to work on v0.5 too, so if nobody has complaints, I will merge it next monday.
