### PR TITLE
Delete ignored key from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -109,7 +109,7 @@
         "control-flow (conditionals)"
       ]
     },
-	{
+    {
       "slug": "atbash-cipher",
       "difficulty": 1,
       "topics": [
@@ -240,12 +240,6 @@
   ],
   "deprecated": [
 
-  ],
-  "ignored": [
-    "bin",
-    "img",
-    "docs",
-    "juliamnt"
   ],
   "foregone": [
 


### PR DESCRIPTION
Since the exercise implementations are all in the exercises directory
we no longer need to ignore any non-exercise directories in the root
of the track.

See https://github.com/exercism/meta/issues/3 for context.