### PR TITLE
Fix runtests: testset results print by default

### DIFF
--- a/runtests.jl
+++ b/runtests.jl
@@ -31,17 +31,12 @@ for (root, dirs, files) in walkdir("exercises")
 
         try
             # Run the tests
-            result = @testset "$exercise example" begin
+            @testset "$exercise example" begin
                 include(joinpath(temp_path, "runtests.jl"))
             end
         finally
             # Delete the temporary directory
             rm(temp_path, recursive=true)
-        end
-
-        # Print test output (this is the default behaviour for older versions of Julia)
-        if VERSION > v"0.6.0-dev"
-            Base.Test.print_test_results(result)
         end
     end
 end


### PR DESCRIPTION
Testsets now print the result by default again (this wasn't the case on earlier v0.6-dev versions) so we don't need the special case anymore.